### PR TITLE
Only depend on support annotations.

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -26,6 +26,6 @@ dependencies {
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support:appcompat-v7:25.1.1'
+    compile 'com.android.support:support-annotations:25.2.0'
     testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
The library currently only needs to depend on support annotations and doesn't need the full appcompat-v7 library.